### PR TITLE
Updating the requests import and adding missing IAM permssions

### DIFF
--- a/function/app.py
+++ b/function/app.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 
 import boto3
-import requests
+from pip._vendor import requests
 from botocore.exceptions import ClientError
 
 # Initialize environment variables

--- a/main.tf
+++ b/main.tf
@@ -41,12 +41,23 @@ data "aws_iam_policy_document" "default" {
       "identitystore:ListGroupMemberships",
       "identitystore:ListGroups",
       "identitystore:ListUsers",
+      "identitystore:DescribeUser",
     ]
     resources = [
       "arn:aws:identitystore::${data.aws_caller_identity.current.account_id}:identitystore/*",
       "arn:aws:identitystore:::user/*",
       "arn:aws:identitystore:::group/*",
       "arn:aws:identitystore:::membership/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sso:ListInstances",
+    ]
+    resources = [
+      "arn:aws:sso:::instance/*"
     ]
   }
 }


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/4271

This PR adds workflow to run integration and unit tests on push to any branch as well ass adds terraform code for a module that does an end-to-end deployment of this lambda function, mirroring the approach here:
https://github.com/ministryofjustice/moj-terraform-scim-github

Fixes in this PR:
* Adding `describeuser` permission
* adding `sso:listinstances` permission
* fixing the `requests` import statement to use the one packaged into the lambda runtime.

Note: Racoon still unhappy but will be fixed.