### PR TITLE
Increase timeout to 5 minutes from 3 seconds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ resource "aws_lambda_function" "default" {
   role          = aws_iam_role.default.arn
   handler       = "app.lambda_handler"
   runtime       = "python3.11"
+  timeout       = 300
 
   filename         = data.archive_file.function.output_path
   source_code_hash = data.archive_file.function.output_base64sha256


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/4271

This bumps the timeout setting on the lambda to 5 minutes from 3 seconds. As is, the lambda was timing out before completing.

