### PR TITLE
Adding a group to hold all EntraID users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ terraform.tfstate
 grant.json
 role.json
 scrap.txt
+todo.txt
 
 # Python
 **/**__pycache__

--- a/function/app.py
+++ b/function/app.py
@@ -344,9 +344,10 @@ def sync_group_members(
     group_name,
     holding_group_info,
     dry_run,
-):  # pylint: disable=R0913
+):  # pylint: disable=R0913,R912
     """
-    Sync members of a specific Azure AD group with AWS Identity Center, and ensure they are also added to the holding group.
+    Sync members of a specific Azure AD group with AWS Identity Center,
+    and ensure they are also added to the holding group.
 
     Args:
         identity_center_client: Boto3 client for Identity Center.
@@ -538,7 +539,7 @@ def remove_members_not_in_azure_groups(
     azure_group_members,
     holding_group_info,
     dry_run,
-):
+):  # pylint: disable=R0912
     """
     Remove users from AWS Identity Center groups if they no longer exist in Azure AD groups,
     and delete users from Identity Center if they are not in any EntraID groups.
@@ -553,7 +554,7 @@ def remove_members_not_in_azure_groups(
     """
     logger.info("Starting to remove users not in Azure groups...")
 
-    for group_name, members in azure_group_members.items():
+    for group_name, members in azure_group_members.items(): # pylint: disable=R1702
         if group_name == HOLDING_GROUP_NAME:
             continue  # Skip holding group in all sync aspects other than those related to the holding group itself
 

--- a/function/app.py
+++ b/function/app.py
@@ -336,7 +336,7 @@ def sync_azure_groups_with_aws(
     return azure_group_members
 
 
-def sync_group_members(
+def sync_group_members(  # pylint: disable=R0913,R0912
     identity_center_client,
     identity_store_id,
     group_info,
@@ -344,7 +344,7 @@ def sync_group_members(
     group_name,
     holding_group_info,
     dry_run,
-):  # pylint: disable=R0913,R912
+):
     """
     Sync members of a specific Azure AD group with AWS Identity Center,
     and ensure they are also added to the holding group.
@@ -532,14 +532,14 @@ def remove_obsolete_groups(
                     logger.error("Error deleting group %s: %s", group_name, e)
 
 
-def remove_members_not_in_azure_groups(
+def remove_members_not_in_azure_groups(  # pylint: disable=R0912,R0914
     identity_center_client,
     identity_store_id,
     aws_groups,
     azure_group_members,
     holding_group_info,
     dry_run,
-):  # pylint: disable=R0912
+):
     """
     Remove users from AWS Identity Center groups if they no longer exist in Azure AD groups,
     and delete users from Identity Center if they are not in any EntraID groups.
@@ -660,7 +660,7 @@ def remove_members_not_in_azure_groups(
     logger.info("Completed removal of users not in Azure groups.")
 
 
-def delete_orphaned_aws_users(
+def delete_orphaned_aws_users(  # pylint: disable=R0913
     identity_center_client,
     identity_store_id,
     aws_groups,
@@ -688,7 +688,7 @@ def delete_orphaned_aws_users(
         all_group_members.update(group["Members"])
 
     # Iterate over all relevant users
-    for user_id in relevant_users:
+    for user_id in relevant_users:  # pylint: disable=R1702
         try:
             user_info = identity_center_client.describe_user(
                 IdentityStoreId=identity_store_id, UserId=user_id

--- a/function/app.py
+++ b/function/app.py
@@ -554,7 +554,7 @@ def remove_members_not_in_azure_groups(
     """
     logger.info("Starting to remove users not in Azure groups...")
 
-    for group_name, members in azure_group_members.items(): # pylint: disable=R1702
+    for group_name, members in azure_group_members.items():  # pylint: disable=R1702
         if group_name == HOLDING_GROUP_NAME:
             continue  # Skip holding group in all sync aspects other than those related to the holding group itself
 

--- a/function/app.py
+++ b/function/app.py
@@ -532,7 +532,7 @@ def remove_obsolete_groups(
                     logger.error("Error deleting group %s: %s", group_name, e)
 
 
-def remove_members_not_in_azure_groups(  # pylint: disable=R0912,R0914
+def remove_members_not_in_azure_groups(  # pylint: disable=R0912,R0914,R0913
     identity_center_client,
     identity_store_id,
     aws_groups,

--- a/function/tests/unit/test_member_syncing.py
+++ b/function/tests/unit/test_member_syncing.py
@@ -45,8 +45,8 @@ class TestMemberSync(unittest.TestCase):
             group_info,
             members,
             "mocked_group_name",
-            holding_group_info=group_info,
             dry_run=False,
+            holding_group_info=group_info,
         )
 
         # Ensure create_user was not called

--- a/function/tests/unit/test_member_syncing.py
+++ b/function/tests/unit/test_member_syncing.py
@@ -45,6 +45,7 @@ class TestMemberSync(unittest.TestCase):
             group_info,
             members,
             "mocked_group_name",
+            holding_group_info=group_info,
             dry_run=False,
         )
 
@@ -79,6 +80,7 @@ class TestMemberSync(unittest.TestCase):
             group_info,
             members,
             "mocked_group_name",
+            holding_group_info=group_info,
             dry_run=False,
         )
 
@@ -112,6 +114,7 @@ class TestMemberSync(unittest.TestCase):
             group_info,
             members,
             "mocked_group_name",
+            holding_group_info=group_info,
             dry_run=True,
         )
 
@@ -145,6 +148,7 @@ class TestMemberSync(unittest.TestCase):
             group_info,
             members,
             "mocked_group_name",
+            holding_group_info=group_info,
             dry_run=False,
         )
 
@@ -190,6 +194,7 @@ class TestMemberSync(unittest.TestCase):
                 group_info,
                 members,
                 "mocked_group_name",
+                holding_group_info=group_info,
                 dry_run=False,
             )
 
@@ -231,6 +236,7 @@ class TestMemberSync(unittest.TestCase):
             "mocked_identity_store_id",
             aws_groups,
             azure_group_members,
+            holding_group_info=aws_groups,
             dry_run=False,
         )
 
@@ -263,6 +269,7 @@ class TestMemberSync(unittest.TestCase):
             "mocked_identity_store_id",
             aws_groups,
             relevant_users,
+            holding_group_info=aws_groups,
             dry_run=False,
         )
 

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,10 @@ resource "aws_lambda_function" "default" {
   #checkov:skip=CKV_AWS_115:No function-level concurrency limit required
   #checkov:skip=CKV_AWS_272:No code-signing configuration required
   #checkov:skip=CKV_AWS_117:Not configuring a VPC for this Lambda
+  #checkov:skip=CKV_AWS_173:All sensitive envvars are retrieved from secrets manager
+  #checkov:skip=CKV_AWS_158:Won't implement
   #ts:skip=AWS.LambdaFunction.Logging.0472:No VPC configuration needed for this Lambda function
+  #ts:skip=AWS.LambdaFunction.EncryptionandKeyManagement.0471:Sensitive vars are read from secrets manager
 
   function_name = local.name
   role          = aws_iam_role.default.arn

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,7 @@ resource "aws_iam_role_policy_attachment" "default" {
 }
 
 resource "aws_cloudwatch_log_group" "default" {
+  #checkov:skip=CKV_AWS_158:Won't implement
   name              = "/aws/lambda/${local.name}"
   retention_in_days = 365
 }

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 data "aws_iam_policy_document" "default" {
+  #checkov:skip=CKV_AWS_158:Won't implement
   statement {
     effect = "Allow"
     actions = [


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/5383

This adds a new group into Identity Center that holds all EntraID users that exist. This is chiefly aimed at simplifying QuickSight onboarding. If an EntraID user is added to an `azure-aws-sso-`-prefixed group, they will be created in the identity center and added to the holding group. Holding group will be added as authors QS group, so this will remove the need to add each group individually. 