### PR TITLE
Filtering out Locally Managed groups and non-justice users

### DIFF
--- a/function/app.py
+++ b/function/app.py
@@ -17,6 +17,12 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 GROUP_PREFIX = "azure-aws-sso-"
 HOLDING_GROUP_NAME = "azure-aws-sso-all-members"
 
+IGNORED_GROUPS = [
+    "azure-aws-sso-analytical-platform-qs-readers",
+    "azure-aws-sso-analytical-platform-qs-authors",
+    "azure-aws-sso-analytical-platform-qs-admins",
+]
+
 # Set up logging
 logger = logging.getLogger()
 logger.setLevel(LOG_LEVEL)
@@ -119,10 +125,14 @@ def get_entraid_group_members(access_token, group_id):
     response_admins = requests.get(url_admins, headers=headers)
     response_admins.raise_for_status()
     admins = response_admins.json()["value"]
-
-    # Combine members and admins
-    combined_members = members + admins
-
+    # raw members and admins
+    raw_members = members + admins
+    # filter out non-justice user
+    combined_members = [
+        member
+        for member in raw_members
+        if member.get("userPrincipalName", "").endswith("justice.gov.uk")
+    ]
     group_members_cache[group_id] = combined_members
     return combined_members
 
@@ -866,6 +876,6 @@ def lambda_handler(event, context):  # pylint: disable=W0621,W0613
 
 if __name__ == "__main__":
     # This is for local testing
-    event = {"dry_run": True}
+    event = {"dry_run": "True"}
     context = None  # pylint: disable=C0103
     lambda_handler(event, context)

--- a/function/app.py
+++ b/function/app.py
@@ -95,7 +95,10 @@ def get_entraid_aws_groups(access_token):
 
     response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()
-    return response.json()["value"]
+    all_groups = response.json()["value"]
+
+    # Filter out ignored groups
+    return [group for group in all_groups if group["displayName"] not in IGNORED_GROUPS]
 
 
 def get_entraid_group_members(access_token, group_id):
@@ -162,6 +165,9 @@ def get_identity_center_groups_and_relevant_users(
                 if group_name_prefix == "" or group["DisplayName"].startswith(
                     group_name_prefix
                 ):
+                    if group["DisplayName"] in IGNORED_GROUPS:
+                        logger.info("Skipping ignored group: %s", group["DisplayName"])
+                        continue
                     groups[group["DisplayName"]] = {
                         "GroupId": group["GroupId"],
                         "Members": set(),
@@ -519,6 +525,9 @@ def remove_obsolete_groups(
     azure_group_names = set(group["displayName"] for group in azure_groups)
     for group_name in list(aws_groups.keys()):
         if group_name not in azure_group_names:
+            if group_name in IGNORED_GROUPS:
+                logger.info("Skipping deletion of ignored group: %s", group_name)
+                continue  # These groups are managed elsewhere
             if group_name == HOLDING_GROUP_NAME:
                 continue  # Don't delete the holding group even if empty
             if dry_run:

--- a/function/requirements-dev.txt
+++ b/function/requirements-dev.txt
@@ -1,9 +1,9 @@
 autopep8==2.3.1
-black==24.4.2
-flake8==7.1.0
+black==24.10.0
+flake8==7.1.1
 isort==5.13.2
 mypy==1.11.0
-pylint==3.2.6
+pylint==3.3.2
 unittest2==1.1.0
 mock==5.1.0
 requests_mock==1.12.1

--- a/function/requirements-dev.txt
+++ b/function/requirements-dev.txt
@@ -9,6 +9,8 @@ mock==5.1.0
 requests_mock==1.12.1
 moto==5.0.13
 
-boto3==1.28.57
-botocore==1.31.57
-requests==2.32.2
+# Core Dependencies
+boto3==1.35.92           # AWS SDK for Python to interact with AWS services
+botocore==1.35.92        # Low-level, data-driven core of boto3
+requests==2.32.3         # To make HTTP requests to EntraID
+

--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -1,4 +1,4 @@
 # Core Dependencies
-boto3==1.28.57           # AWS SDK for Python to interact with AWS services
-botocore==1.31.57        # Low-level, data-driven core of boto3
-requests==2.32.2         # To make HTTP requests to EntraID
+boto3==1.35.92           # AWS SDK for Python to interact with AWS services
+botocore==1.35.92        # Low-level, data-driven core of boto3
+requests==2.32.3         # To make HTTP requests to EntraID


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/6510

This PR defines a set of groups that the synchronisation lambda should ignore as they will be retrieved and managed via Analytical Platform Control Panel
