### PR TITLE
🔥 Remove Exception Propogation When Failing to Add User to Group

### DIFF
--- a/function/app.py
+++ b/function/app.py
@@ -473,7 +473,6 @@ def sync_group_members(  # pylint: disable=R0913,R0912
                             group_name,
                             e,
                         )
-                        raise e
 
         # Ensure the user is added to the holding group
         if user_id and member_name not in holding_group_info["Members"]:
@@ -505,7 +504,6 @@ def sync_group_members(  # pylint: disable=R0913,R0912
                             member_name,
                             e,
                         )
-                        raise e
 
 
 def remove_obsolete_groups(

--- a/function/app.py
+++ b/function/app.py
@@ -432,7 +432,6 @@ def sync_group_members(  # pylint: disable=R0913,R0912
                         member_name,
                         e,
                     )
-                    raise e
 
         # Add the user to the group if they are not already a member
         if member_name not in group_info["Members"]:


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://mojdt.slack.com/archives/C01A7QK5VM1/p1746005954928459
- To prevent the script from being blocked by an issue with a single user

## ♻️ What's changed

- Removed the propagation of the exception when the client has issues adding a user, allowing others users to still be added

## 📝 Notes

- A short-term fix to attempt to get the job working again, we may need more amendments to get it working.
- We should create an additional ticket to improve monitoring and resilience of this process