### PR TITLE
Bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ module "scim" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.4.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "aws_lambda_function" "default" {
   function_name = local.name
   role          = aws_iam_role.default.arn
   handler       = "app.lambda_handler"
-  runtime       = "python3.11"
+  runtime       = "python3.13"
   timeout       = 300
 
   filename         = data.archive_file.function.output_path

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
Bump dependencies - Python version 3.13 and Terraform AWS provider 6